### PR TITLE
Metta writer

### DIFF
--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/task/InsertTask.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/task/InsertTask.java
@@ -30,6 +30,7 @@ import org.apache.hugegraph.loader.mapping.ElementMapping;
 import org.apache.hugegraph.loader.mapping.InputStruct;
 import org.apache.hugegraph.loader.metrics.LoadMetrics;
 import org.apache.hugegraph.loader.metrics.LoadSummary;
+import org.apache.hugegraph.loader.writer.MeTTaWriter;
 import org.apache.hugegraph.structure.GraphElement;
 import org.apache.hugegraph.structure.graph.BatchEdgeRequest;
 import org.apache.hugegraph.structure.graph.BatchVertexRequest;
@@ -56,6 +57,7 @@ public abstract class InsertTask implements Runnable {
     protected final InputStruct struct;
     protected final ElementMapping mapping;
     protected final List<Record> batch;
+    protected final MeTTaWriter mettaWriter;
 
     public InsertTask(LoadContext context, InputStruct struct,
                       ElementMapping mapping, List<Record> batch) {
@@ -64,6 +66,7 @@ public abstract class InsertTask implements Runnable {
         this.struct = struct;
         this.mapping = mapping;
         this.batch = batch;
+        this.mettaWriter = new MeTTaWriter();
     }
 
     public ElemType type() {
@@ -111,10 +114,12 @@ public abstract class InsertTask implements Runnable {
         List<GraphElement> elements = new ArrayList<>(batch.size());
         batch.forEach(r -> elements.add(r.element()));
         if (this.type().isVertex()) {
-            client.graph().addVertices((List<Vertex>) (Object) elements);
+            // client.graph().addVertices((List<Vertex>) (Object) elements);
+            this.mettaWriter.writeNodes(batch);
         } else {
-            client.graph().addEdges((List<Edge>) (Object) elements,
-                                    checkVertex);
+            // client.graph().addEdges((List<Edge>) (Object) elements,
+                                    // checkVertex);
+            this.mettaWriter.writeEdges(batch);
         }
     }
 

--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/MeTTaWriter.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/MeTTaWriter.java
@@ -1,0 +1,224 @@
+package org.apache.hugegraph.loader.writer;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.loader.builder.Record;
+import org.apache.hugegraph.structure.graph.Edge;
+import org.apache.hugegraph.structure.graph.Vertex;
+
+public class MeTTaWriter {
+    
+    private static final String OUTPUT_DIR = "/home/developer/Desktop/metta_output";
+    
+    public MeTTaWriter() {
+        // Create output directory if it doesn't exist
+        try {
+            Files.createDirectories(Paths.get(OUTPUT_DIR));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create output directory", e);
+        }
+    }
+    
+    /**
+     * Write a list of vertices to MeTTa files, one file per label
+     */
+    public void writeNodes(List<Record> records) {
+        Map<String, List<Vertex>> verticesByLabel = groupVerticesByLabel(records);
+        
+        for (Map.Entry<String, List<Vertex>> entry : verticesByLabel.entrySet()) {
+            String label = entry.getKey();
+            List<Vertex> vertices = entry.getValue();
+            
+            String filePath = OUTPUT_DIR + "/" + label +"_nodes"+ ".metta";
+            
+            try (FileWriter writer = new FileWriter(filePath, true)) {
+                for (Vertex vertex : vertices) {
+                    String mettaNode = writeNode(vertex);
+                    writer.write(mettaNode + "\n");
+                }
+                writer.write("\n");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to write nodes to file: " + filePath, e);
+            }
+        }
+    }
+    
+    /**
+     * Write a single vertex to MeTTa format
+     */
+    public String writeNode(Vertex vertex) {
+        String id = vertex.id().toString();
+        String label = vertex.label();
+        Map<String, Object> properties = vertex.properties();
+        
+        StringBuilder result = new StringBuilder();
+        result.append("(").append(label).append(" ").append(id).append(")");
+        
+        // Add properties
+        for (Map.Entry<String, Object> prop : properties.entrySet()) {
+            String key = prop.getKey();
+            Object value = prop.getValue();
+            
+            if (value != null && !value.toString().isEmpty()) {
+                result.append("\n(").append(key).append(" (").append(label).append(" ").append(id).append(") ");
+                
+                // Handle different property types
+                if (value instanceof List) {
+                    result.append("(");
+                    List<?> list = (List<?>) value;
+                    for (int i = 0; i < list.size(); i++) {
+                        result.append(checkProperty(list.get(i).toString()));
+                        if (i < list.size() - 1) {
+                            result.append(" ");
+                        }
+                    }
+                    result.append(")");
+                } else {
+                    result.append(checkProperty(value.toString()));
+                }
+                
+                result.append(")");
+            }
+        }
+        
+        return result.toString();
+    }
+    
+    /**
+     * Write a list of edges to MeTTa files, one file per label
+     */
+    public void writeEdges(List<Record> records) {
+        Map<String, List<Edge>> edgesByLabel = groupEdgesByLabel(records);
+        
+        for (Map.Entry<String, List<Edge>> entry : edgesByLabel.entrySet()) {
+            String label = entry.getKey();
+            List<Edge> edges = entry.getValue();
+            
+            String filePath = OUTPUT_DIR + "/" + label +"_edges"+ ".metta";
+            
+            try (FileWriter writer = new FileWriter(filePath, true)) {
+                for (Edge edge : edges) {
+                    String mettaEdge = writeEdge(edge);
+                    writer.write(mettaEdge + "\n");
+                }
+                writer.write("\n");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to write edges to file: " + filePath, e);
+            }
+        }
+    }
+    
+    /**
+     * Write a single edge to MeTTa format
+     */
+    public String writeEdge(Edge edge) {
+        String sourceId = edge.sourceId().toString();
+        String targetId = edge.targetId().toString();
+        String sourceLabel = edge.sourceLabel();
+        String targetLabel = edge.targetLabel();
+        String label = edge.label();
+        Map<String, Object> properties = edge.properties();
+        
+        StringBuilder result = new StringBuilder();
+        result.append("(").append(label).append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
+              .append("(").append(targetLabel).append(" ").append(targetId).append("))");
+        
+        // Add properties
+        for (Map.Entry<String, Object> prop : properties.entrySet()) {
+            String key = prop.getKey();
+            Object value = prop.getValue();
+            
+            if (value != null && !value.toString().isEmpty()) {
+                result.append("\n(").append(key).append(" (").append(label)
+                      .append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
+                      .append("(").append(targetLabel).append(" ").append(targetId).append(")) ");
+                
+                // Handle different property types
+                if (value instanceof List) {
+                    result.append("(");
+                    List<?> list = (List<?>) value;
+                    for (int i = 0; i < list.size(); i++) {
+                        result.append(checkProperty(list.get(i).toString()));
+                        if (i < list.size() - 1) {
+                            result.append(" ");
+                        }
+                    }
+                    result.append(")");
+                } else {
+                    result.append(checkProperty(value.toString()));
+                }
+                
+                result.append(")");
+            }
+        }
+        
+        return result.toString();
+    }
+    
+    /**
+     * Helper method to escape special characters in property values
+     */
+    private String checkProperty(String prop) {
+        if (prop.contains(" ")) {
+            prop = prop.replace(" ", "_");
+        }
+        
+        // Escape special characters
+        String[] specialChars = {"(", ")"};
+        String escapeChar = "\\";
+        
+        for (String special : specialChars) {
+            prop = prop.replace(special, escapeChar + special);
+        }
+        
+        return prop;
+    }
+    
+    /**
+     * Group vertices by their label
+     */
+    private Map<String, List<Vertex>> groupVerticesByLabel(List<Record> records) {
+        Map<String, List<Vertex>> result = new java.util.HashMap<>();
+        
+        for (Record record : records) {
+            Vertex vertex = (Vertex) record.element();
+            String label = vertex.label();
+            
+            if (!result.containsKey(label)) {
+                result.put(label, new ArrayList<>());
+            }
+            
+            result.get(label).add(vertex);
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Group edges by their label
+     */
+    private Map<String, List<Edge>> groupEdgesByLabel(List<Record> records) {
+        Map<String, List<Edge>> result = new java.util.HashMap<>();
+        
+        for (Record record : records) {
+            Edge edge = (Edge) record.element();
+            String label = edge.label();
+            
+            if (!result.containsKey(label)) {
+                result.put(label, new ArrayList<>());
+            }
+            
+            result.get(label).add(edge);
+        }
+        
+        return result;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <zookeeper.version>3.6.2</zookeeper.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.8.47</mockito.version>
-        <lombok.version>1.18.8</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang3.version>3.9</commons.lang3.version>
         <commons.compress.version>1.21</commons.compress.version>


### PR DESCRIPTION
## **Overview**
Replaces HugeGraph database writer with MeTTa Writer to output graph data in MeTTa format compatible with Hyperon's AtomSpace.

## **Key Features**
- **Graph-to-MeTTa Conversion:** Transforms vertices and edges into MeTTa logical expressions
- **Label-based Organization:** Groups output by labels into separate `.metta` files (`{label}_nodes.metta`, `{label}_edges.metta`)
- **Property Handling:** Preserves all properties with type-aware serialization and special character escaping
- **File Management:** Creates organized output directory with append support for large datasets

## **Example Output**

**Node:**
```metta
(Person john_doe)
(name (Person john_doe) John_Doe)
(age (Person john_doe) 30)
```

**Edge:**
```metta
(WORKS_FOR (Person john_doe) (Company tech_corp))
(start_date (WORKS_FOR (Person john_doe) (Company tech_corp)) 2020-01-15)
```

## **Technical Details**
- **Core Methods:** `writeNode()`, `writeEdge()`, `groupVerticesByLabel()`, `groupEdgesByLabel()`
- **Output Directory:** `/home/developer/Desktop/metta_output` (auto-created)
- **Integration:** Direct replacement in HugeGraph Loader pipeline
- **Error Handling:** Robust exception handling with meaningful messages


**Pipeline:** `[Input Data] → [HugeGraph Parser] → [MeTTa Writer] → [.metta Files] → [AtomSpace]`